### PR TITLE
* updating to the 1.0 src

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'typescript-src', '~> 1.0' #path: '../typescript-src-ruby'
+
 group :development do
   gem "rake"
   gem "rspec"

--- a/lib/typescript-node/version.rb
+++ b/lib/typescript-node/version.rb
@@ -1,5 +1,5 @@
 module TypeScript
   module Node
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end

--- a/spec/typescript-node_spec.rb
+++ b/spec/typescript-node_spec.rb
@@ -10,7 +10,7 @@ module TypeScript
 
       its(:exit_status) { should == 0 }
       it { should be_success }
-      its(:js) { should == "console.log(\"Hello TypeScript\");\r\n" }
+      its(:js) { should == "console.log(\"Hello TypeScript\");\n" }
       its(:stdout) { should == "" }
       its(:stderr) { should == "" }
     end

--- a/typescript-node.gemspec
+++ b/typescript-node.gemspec
@@ -14,6 +14,4 @@ Gem::Specification.new do |gem|
   gem.name          = "typescript-node"
   gem.require_paths = ["lib"]
   gem.version       = TypeScript::Node::VERSION
-
-  gem.add_dependency 'typescript-src', '~> 0.8'
 end


### PR DESCRIPTION
The tests pass as long as I removed the \r\n and changed it to \n.  I'm not sure if this is because I'm on a mac, or if typescript changed in this way.

Also, I moved the typescript-src dependency to the gemfile because gemspec is limited in what you can specify... for example, path: dependencies which I need to easily turn on while depending on the unpublished typescript-node-src fork of mine.
