### PR TITLE
Use extension when compiling

### DIFF
--- a/lib/typescript-node.rb
+++ b/lib/typescript-node.rb
@@ -39,8 +39,8 @@ module TypeScript
       # Compile TypeScript to JavaScript.
       # @param [String] source TypeScript to be compiled
       # @return [String] Resulted JavaScript
-      def compile(source, *tsc_options)
-        js_file = Tempfile.new(%w(typescript-node .ts))
+      def compile(source, extension, *tsc_options)
+        js_file = Tempfile.new(["typescript-node", extension])
         begin
           js_file.write(source)
           js_file.close


### PR DESCRIPTION
This pull request adds support so that the the extension of the original file is used when compiling. This is because typescript supports `.ts` and `.tsx`. Depending the extension the support of JSX is enabled or disabled. This feature could be used in typescript-rails and would need to be merged before `tsx` support is added.
